### PR TITLE
Replace Avail Goldberg Testnet with an up-to-date Turing one

### DIFF
--- a/chains/all_chains_types.json
+++ b/chains/all_chains_types.json
@@ -1990,8 +1990,8 @@
     ]
   },
   {
-    "chainId": "6f09966420b2608d1947ccfb0f2a362450d1fc7fd902c29b67c906eaa965a7ae",
-    "runtime_id": 22,
+    "chainId": "d3d2f3a3495dc597434a99d7d449ebad6616db45e4e4f178f31cc6fa14378b70",
+    "runtime_id": 30,
     "types": { },
     "versioning": [
         {

--- a/chains/all_chains_types_android.json
+++ b/chains/all_chains_types_android.json
@@ -2226,8 +2226,8 @@
     ]
   },
   {
-    "chainId": "6f09966420b2608d1947ccfb0f2a362450d1fc7fd902c29b67c906eaa965a7ae",
-    "runtime_id": 22,
+    "chainId": "d3d2f3a3495dc597434a99d7d449ebad6616db45e4e4f178f31cc6fa14378b70",
+    "runtime_id": 30,
     "types": {},
     "versioning": [
       {

--- a/chains/v9/chains.json
+++ b/chains/v9/chains.json
@@ -7301,8 +7301,8 @@
   },
   {
           "disabled": false,
-          "chainId": "6f09966420b2608d1947ccfb0f2a362450d1fc7fd902c29b67c906eaa965a7ae",
-          "name": "Avail Goldberg Testnet",
+          "chainId": "d3d2f3a3495dc597434a99d7d449ebad6616db45e4e4f178f31cc6fa14378b70",
+          "name": "Avail Turing Testnet",
           "externalApi": {
               "explorers": [{
                   "type": "subscan",
@@ -7310,14 +7310,14 @@
                       "extrinsic",
                       "account"
                   ],
-                  "url": "https://avail-testnet.subscan.io/{type}/{value}"
+                  "url": "https://avail-turing.subscan.io/{type}/{value}"
               }]
           },
           "assets": [
               {
               "id": "72778e65-53b6-4cb4-bb4c-c029121eb494",
               "name": "avail token",
-              "symbol": "avl",
+              "symbol": "avail",
               "precision": 18,
               "icon": "https://raw.githubusercontent.com/soramitsu/shared-features-utils/master/icons/chains/white/Avail.svg",
               "color": "56E5FF",
@@ -7326,8 +7326,8 @@
           }
       ],
           "nodes": [{
-                  "url": "wss://goldberg-testnet-rpc.avail.tools/ws",
-                  "name": "Avail Goldberg Testnet node"
+                  "url": "wss://turing-rpc.avail.so/ws",
+                  "name": "Avail Turing Testnet node"
               }
       
           ],


### PR DESCRIPTION
✅ Update types
✅ Replace chain spec for Avail Testnet